### PR TITLE
Added _nullptr type mock for undefined native nullptr type cases

### DIFF
--- a/include/_nullptr.h
+++ b/include/_nullptr.h
@@ -1,0 +1,20 @@
+/**
+ * Adapted from Scott Meyer's Effective C++ book.
+ * Used for cases when nullptr type is not available with older versions.
+ */
+
+const
+class nullptr_t {
+  public:
+    template<class T>
+    inline operator T*() const
+    { return 0; }
+
+    template<class C, class T>
+    inline operator T C::*() const
+    { return 0; }
+
+  private:
+    void operator&() const;
+
+} nullptr = {};

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,4 @@
-var Buffer = new Buffer();
+var buffer = new Buffer();
 var threx = require('../build/Release/threx');
 var Thread = threx.Thread;
 
@@ -7,7 +7,7 @@ Thread.prototype.join = threx.join;
 Thread.prototype.enqueue = threx.enqueue;
 
 Thread.prototype.enqueue = function enqueue(obj, data) {
-  if (data instanceof Buffer &&
+  if (data instanceof buffer &&
       data.parent !== undefined)
     throw new Error('Buffer should not be from a slice');
   return threx.enqueue.call(this, obj, data);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,4 @@
-var buffer = new Buffer();
+var buffer = new Buffer(2);
 var threx = require('../build/Release/threx');
 var Thread = threx.Thread;
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,4 @@
-var Buffer = require('buffer').Buffer;
+var Buffer = new Buffer();
 var threx = require('../build/Release/threx');
 var Thread = threx.Thread;
 
@@ -11,6 +11,6 @@ Thread.prototype.enqueue = function enqueue(obj, data) {
       data.parent !== undefined)
     throw new Error('Buffer should not be from a slice');
   return threx.enqueue.call(this, obj, data);
-}
+};
 
 module.exports = Thread;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,3 @@
-var buffer = new Buffer(2);
 var threx = require('../build/Release/threx');
 var Thread = threx.Thread;
 
@@ -7,8 +6,7 @@ Thread.prototype.join = threx.join;
 Thread.prototype.enqueue = threx.enqueue;
 
 Thread.prototype.enqueue = function enqueue(obj, data) {
-  if (data instanceof buffer &&
-      data.parent !== undefined)
+  if (data.parent !== undefined)
     throw new Error('Buffer should not be from a slice');
   return threx.enqueue.call(this, obj, data);
 };

--- a/src/main.cc
+++ b/src/main.cc
@@ -2,7 +2,7 @@
  * See ../include/_nullptr (Reference to Scott Meyer)
  */
 #if _MSC_VER < 1600 //MSVC version < 8
-     #include "_nullptr.h"
+     #include "../include/_nullptr.h"
 #endif
 
 #include "../include/threx.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,3 +1,10 @@
+/**
+ * See ../include/_nullptr (Reference to Scott Meyer)
+ */
+#if _MSC_VER < 1600 //MSVC version < 8
+     #include "../include/_nullptr.h"
+#endif
+
 #include "../include/threx.h"
 #include "../deps/fuq/fuq.h"
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,3 +1,10 @@
+/**
+ * See ../include/_nullptr (Reference to Scott Meyer)
+ */
+#if _MSC_VER < 1600 //MSVC version < 8
+     #include "_nullptr.h"
+#endif
+
 #include "../include/threx.h"
 #include "../deps/fuq/fuq.h"
 


### PR DESCRIPTION
Make fails on older versions of gcc when compiling because of the type nullptr. Added adapter from a Scott Meyers - C++ Book and reference from stackoverflow. NPM now installs correctly when node-gyp builds the .gyp file :) @trevnorris 
