### PR TITLE
Add _nullptr polyfill for older versions of gcc

### DIFF
--- a/include/threx.h
+++ b/include/threx.h
@@ -1,6 +1,9 @@
 #ifndef INCLUDE_THREX_H_
 #define INCLUDE_THREX_H_
 
+#if _MSC_VER < 1600 //MSVC version < 8
+     #include "../src/nullptr/_nullptr.h"
+#endif
 #include "../deps/fuq/fuq.h"
 #include <uv.h>
 #include <v8.h>

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,6 +11,6 @@ Thread.prototype.enqueue = function enqueue(obj, data) {
       data.parent !== undefined)
     throw new Error('Buffer should not be from a slice');
   return threx.enqueue.call(this, obj, data);
-}
+};
 
 module.exports = Thread;

--- a/src/_nullptr.h
+++ b/src/_nullptr.h
@@ -1,0 +1,20 @@
+/**
+ * Adapted from Scott Meyer's Effective C++ book.
+ * Used for cases when nullptr type is not available with older versions.
+ */
+
+const
+class nullptr_t {
+  public:
+    template<class T>
+    inline operator T*() const
+    { return 0; }
+
+    template<class C, class T>
+    inline operator T C::*() const
+    { return 0; }
+
+  private:
+    void operator&() const;
+
+} nullptr = {};


### PR DESCRIPTION
This helps resolve make conflicts when binding to gyp. My previous fork was messy and I just now got around to fixing it and cleaning it up. @trevnorris hope this is cool.
